### PR TITLE
Migrate to asyncio

### DIFF
--- a/repype/batch.py
+++ b/repype/batch.py
@@ -84,9 +84,9 @@ def run_task_process(rc, status) -> int:
 
 
 if __name__ == '__main__':
-    rc, status = dill.load(sys.stdin)
+    rc, status = dill.load(sys.stdin.buffer)
     exit_code = run_task_process(rc, status)
-    sys.stdout.write(exit_code)
+    sys.stdout.write(str(exit_code))
 
 
 class Batch:
@@ -216,11 +216,13 @@ class Batch:
                 # Run the task in a separate process
                 self.task_process = await asyncio.create_subprocess_exec(
                     sys.executable,
+                    '-m'
                     'repype.batch',
                     stdin = asyncio.subprocess.PIPE,
                     stdout = asyncio.subprocess.PIPE,
                 )
-                exit_code = await self.task_process.communicate(input = dill.dumps((rc, task_status),))[0]
+                stdout = (await self.task_process.communicate(input = dill.dumps((rc, task_status),)))[0]
+                exit_code = int(stdout) if stdout else None
                 if exit_code != 0:
                     repype.status.update(
                         status = status,

--- a/repype/batch.py
+++ b/repype/batch.py
@@ -1,7 +1,9 @@
+import asyncio
 import glob
 import multiprocessing
 import multiprocessing.connection
 import pathlib
+import signal
 import sys
 import traceback
 
@@ -50,27 +52,23 @@ class RunContext:
         self.config = task.create_config()
 
 
-def run_task_process(exit_code: multiprocessing.connection.Connection, args_serialized: bytes) -> None:
+def run_task_process(rc, status) -> int:
     """
     Run a task using specific :class:`RunContext` and :class:`repype.status.Status` objects inside a separate process.
-
-    The exit code of the process is sent to the parent process using the `exit_code` connection.
-    This is to bypass some interference between the `exitcode` attribute of ``multiprocessing.Process`` objects and threaded workers in Textual:
-    https://github.com/Textualize/textual/discussions/4923
-    The exit code is 0 upon successful completion, and 1 indicates failure.
 
     Arguments:
         exit_code: The connection to send the exit code to.
         args_serialized: The serialized arguments to run the task.
             This should be a tuple of the shape ``(rc, status)``, where ``rc`` is a :class:`RunContext` object
             and ``status`` is a :class:`repype.status.Status` object, serialized using dill.
-    """
-    rc, status = dill.loads(args_serialized)
 
+    Returns:
+        0 upon successful completion, and 1 indicates failure.
+    """
     # Run the task and exit the child process
     try:
         rc.task.run(rc.config, pipeline = rc.pipeline, status = status)
-        exit_code.send(0)  # Indicate success to the parent process
+        return 0  # Indicate success to the parent process
 
     # If an exception occurs, update the status and re-raise the exception
     except:
@@ -82,7 +80,13 @@ def run_task_process(exit_code: multiprocessing.connection.Connection, args_seri
             traceback = traceback.format_exc(),
             stage = error.stage.id if isinstance(error, repype.pipeline.StageError) else None,
         )
-        exit_code.send(1)  # Indicate a failure to the parent process
+        return 1  # Indicate a failure to the parent process
+
+
+if __name__ == '__main__':
+    rc, status = dill.load(sys.stdin)
+    exit_code = run_task_process(rc, status)
+    sys.stdout.write(exit_code)
 
 
 class Batch:
@@ -180,7 +184,7 @@ class Batch:
         """
         return [rc for rc in self.contexts if rc.task.is_pending(rc.pipeline, rc.config)]
 
-    def run(self, contexts: Optional[List[RunContext]] = None, status: Optional[repype.status.Status] = None) -> bool:
+    async def run(self, contexts: Optional[List[RunContext]] = None, status: Optional[repype.status.Status] = None) -> bool:
         """
         Run all pending tasks (or a subset).
 
@@ -210,13 +214,13 @@ class Batch:
                 )
 
                 # Run the task in a separate process
-                self.task_pipe = multiprocessing.Pipe(duplex = False)
-                self.task_process = multiprocessing.Process(target = run_task_process, args = (self.task_pipe[1], dill.dumps((rc, task_status),),))
-                self.task_process.start()
-
-                # Wait for the task process to finish
-                self.task_process.join()
-                exit_code = self.task_pipe[0].recv()
+                self.task_process = await asyncio.create_subprocess_exec(
+                    sys.executable,
+                    'repype.batch',
+                    stdin = asyncio.subprocess.PIPE,
+                    stdout = asyncio.subprocess.PIPE,
+                )
+                exit_code = await self.task_process.communicate(input = dill.dumps((rc, task_status),))[0]
                 if exit_code != 0:
                     repype.status.update(
                         status = status,
@@ -233,20 +237,10 @@ class Batch:
         finally:
             self.task_process = None
 
-    def cancel(self) -> None:
+    async def cancel(self) -> None:
         """
         Cancel currently running tasks.
         """
         if self.task_process:
-
-            # Try to terminate the process using SIGTERM (wait at most 1 second)
-            self.task_process.terminate()
-            self.task_process.join(1)
-
-            # Check whether the process ended, if not, ultimately kill it using SIGKILL
-            if self.task_process.exitcode is None:
-                self.task_process.kill()
-                self.task_process.join()
-
-            # The `run` method is sitll waiting for the exit code, so send a value to unblock it
-            self.task_pipe[1].send(2)
+            self.task_process.send_signal(signal.CTRL_C_EVENT)
+            await self.task_process.wait()

--- a/repype/batch.py
+++ b/repype/batch.py
@@ -227,7 +227,7 @@ class Batch:
                     repype.status.update(
                         status = status,
                         info = 'interrupted',
-                        exit_code = exit_code,
+                        exit_code = exit_code,  # exit_code is None if the process was killed, and 1 if an exception was raised in the child process
                     )
 
                     # Interrupt task execution due to an error
@@ -241,8 +241,10 @@ class Batch:
 
     async def cancel(self) -> None:
         """
-        Cancel currently running tasks.
+        Cancel currently running tasks (if any).
         """
         if self.task_process:
-            self.task_process.send_signal(signal.CTRL_C_EVENT)
+            self.task_process.terminate()
+            if self.task_process.returncode is not None:
+                self.task_process.kill()
             await self.task_process.wait()

--- a/repype/cli.py
+++ b/repype/cli.py
@@ -265,14 +265,17 @@ def run_cli_ex(
             run = run,
         )
 
-        status_reader = status_reader_cls(status.filepath)
-        with status_reader:
+        async def main():
+            status_reader = status_reader_cls(status.filepath)
+            async with status_reader:
 
-            if run:
-                return asyncio.run(batch.run(contexts, status = status))
-            
-            else:
-                return True
+                if run:
+                    return await batch.run(contexts, status = status)
+                
+                else:
+                    return True
+        
+        return asyncio.run(main())
 
 
 if __name__ == '__main__':

--- a/repype/cli.py
+++ b/repype/cli.py
@@ -1,4 +1,4 @@
-import argparse
+import asyncio
 import pathlib
 import sys
 import tempfile
@@ -269,7 +269,7 @@ def run_cli_ex(
         with status_reader:
 
             if run:
-                return batch.run(contexts, status = status)
+                return asyncio.run(batch.run(contexts, status = status))
             
             else:
                 return True

--- a/repype/status.py
+++ b/repype/status.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 import pathlib
@@ -489,8 +490,10 @@ class StatusReader(FileSystemEventHandler):
         """
         if isinstance(event, FileModifiedEvent):
             filepath = pathlib.Path(event.src_path).resolve()
-            if self.update(filepath):
-                self.check_new_status()
+            async def update(filepath):
+                if self.update(filepath):
+                    self.check_new_status()
+            asyncio.get_event_loop().call_soon_threadsafe(update, filepath)
 
     def check_new_status(self) -> None:
         """

--- a/repype/status.py
+++ b/repype/status.py
@@ -393,7 +393,8 @@ class StatusReader(FileSystemEventHandler):
     Points to the latest permanent (i.e. non-intermediate) status update within :attr:`data`.
     """
 
-    def __init__(self, filepath: PathLike):
+    def __init__(self, filepath: PathLike, loop: asyncio.AbstractEventLoop = None):
+        self.loop = loop if loop else asyncio.get_running_loop()
         self.filepath = pathlib.Path(filepath).resolve()
         self.data = list()
         self.data_frames = {self.filepath: self.data}
@@ -490,10 +491,10 @@ class StatusReader(FileSystemEventHandler):
         """
         if isinstance(event, FileModifiedEvent):
             filepath = pathlib.Path(event.src_path).resolve()
-            async def update(filepath):
+            def update(filepath):
                 if self.update(filepath):
                     self.check_new_status()
-            asyncio.get_event_loop().call_soon_threadsafe(update, filepath)
+            self.loop.call_soon_threadsafe(update, filepath)
 
     def check_new_status(self) -> None:
         """

--- a/repype/status.py
+++ b/repype/status.py
@@ -404,14 +404,14 @@ class StatusReader(FileSystemEventHandler):
         self.update(self.filepath)
         self.check_new_status()
 
-    def __enter__(self) -> dict:
+    async def __aenter__(self) -> dict:
         self.observer = Observer()
         self.observer.schedule(self, self.filepath.parent, recursive = False)
         self.observer.start()
         return self.data
     
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        time.sleep(1)  # Give the WatchDog observer some extra time
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await asyncio.sleep(1)  # Give the WatchDog observer some extra time
         self.observer.stop()
         self.observer.join()
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -174,7 +174,7 @@ class Batch__contexts(unittest.TestCase):
         )
 
 
-class Batch__run(unittest.TestCase):
+class Batch__run(unittest.IsolatedAsyncioTestCase):
 
     stage1_cls = testsuite.create_stage_class(id = 'stage1')
     stage2_cls = testsuite.create_stage_class(id = 'stage2')
@@ -206,8 +206,8 @@ class Batch__run(unittest.TestCase):
         self.tempdir.cleanup()
 
     @testsuite.with_temporary_paths(1)
-    def test(self, path):
+    async def test(self, path):
         status = repype.status.Status(path = path)
-        ret = self.batch.run(status = status)
+        ret = await self.batch.run(status = status)
         self.assertTrue(ret)
         self.assertEqual([list(item.keys()) for item in status.data], [['expand']] * 3, '\n' + pprint.pformat(status.data))

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,12 +1,15 @@
+import asyncio
 import pathlib
 import pprint
 import tempfile
+import time
 import unittest
 
 import repype.batch
 import repype.pipeline
 import repype.task
 from . import testsuite
+from . import test_cli
 import repype.status
 
 
@@ -210,4 +213,36 @@ class Batch__run(unittest.IsolatedAsyncioTestCase):
         status = repype.status.Status(path = path)
         ret = await self.batch.run(status = status)
         self.assertTrue(ret)
+        self.assertEqual([list(item.keys()) for item in status.data], [['expand']] * 3, '\n' + pprint.pformat(status.data))
+
+
+class Batch__cancel(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.batch__run = Batch__run()
+        self.batch__run.setUp()
+        self.batch = repype.batch.Batch(task_cls = test_cli.DelayedTask)
+        self.batch.load(self.batch__run.root_path)
+
+    def tearDown(self):
+        self.batch__run.tearDown()
+
+    @testsuite.with_temporary_paths(1)
+    async def test(self, path):
+        # Start the run, but do not await
+        t0 = time.time()
+        status = repype.status.Status(path = path)
+        run_future = self.batch.run(status = status)
+
+        # Do the cancellation after 1 second
+        await asyncio.sleep(1)
+        await self.batch.cancel()
+
+        # Wait for the run to finish
+        ret = await run_future
+        dt = time.time() - t0
+
+        # Verify the results
+        self.assertFalse(ret)
+        self.assertLessEqual(abs(dt - 1), 0.1)
         self.assertEqual([list(item.keys()) for item in status.data], [['expand']] * 3, '\n' + pprint.pformat(status.data))

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -354,7 +354,7 @@ class StatusReader__init(IsolatedAsyncioTestCase):
 
     @patch.object(repype.status.StatusReader, 'handle_new_status')
     async def test_without_intermediates(self, mock_handle_new_status):
-        with repype.status.StatusReader(self.status1.filepath) as status:
+        async with repype.status.StatusReader(self.status1.filepath) as status:
             self.assertEqual(status, ['write1', ['write2']])
 
             await wait_for_watchdog()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,11 +1,12 @@
-import contextlib
-import io
+import asyncio
 import json
 import os
-import platform
 import tempfile
 import time
-from unittest import TestCase
+from unittest import (
+    IsolatedAsyncioTestCase,
+    TestCase,
+)
 from unittest.mock import (
     call,
     patch,
@@ -15,9 +16,9 @@ import repype.status
 from . import testsuite
 
 
-def wait_for_watchdog():
+async def wait_for_watchdog():
     timeout = float(os.environ.get('REPYPE_WATCHDOG_TIMEOUT', 0.1))
-    time.sleep(timeout)
+    await asyncio.sleep(timeout)
 
 
 class Status__init(TestCase):
@@ -339,7 +340,7 @@ class update(TestCase):
             self.assertEqual(len(data), 0)
 
 
-class StatusReader__init(TestCase):
+class StatusReader__init(IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.tempdir = tempfile.TemporaryDirectory()
@@ -352,11 +353,11 @@ class StatusReader__init(TestCase):
         self.tempdir.cleanup()
 
     @patch.object(repype.status.StatusReader, 'handle_new_status')
-    def test_without_intermediates(self, mock_handle_new_status):
+    async def test_without_intermediates(self, mock_handle_new_status):
         with repype.status.StatusReader(self.status1.filepath) as status:
             self.assertEqual(status, ['write1', ['write2']])
 
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(
                 mock_handle_new_status.call_args_list,
                 [
@@ -367,7 +368,7 @@ class StatusReader__init(TestCase):
 
             mock_handle_new_status.reset_mock()
             self.status2.write('write3')
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(status, ['write1', ['write2', 'write3']])
             self.assertEqual(
                 mock_handle_new_status.call_args_list,
@@ -379,7 +380,7 @@ class StatusReader__init(TestCase):
             mock_handle_new_status.reset_mock()
             status3 = self.status1.derive()
             status3.write('write4')
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(status, ['write1', ['write2', 'write3'], ['write4']])
             self.assertEqual(
                 mock_handle_new_status.call_args_list,
@@ -390,7 +391,7 @@ class StatusReader__init(TestCase):
 
             mock_handle_new_status.reset_mock()
             self.status1.write('write5')
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(status, ['write1', ['write2', 'write3'], ['write4'], 'write5'])
             self.assertEqual(
                 mock_handle_new_status.call_args_list,

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -401,17 +401,17 @@ class StatusReader__init(IsolatedAsyncioTestCase):
             )
 
     @patch.object(repype.status.StatusReader, 'handle_new_status')
-    def test_with_intermediates(self, mock_handle_new_status):
-        with repype.status.StatusReader(self.status1.filepath) as status:
+    async def test_with_intermediates(self, mock_handle_new_status):
+        async with repype.status.StatusReader(self.status1.filepath) as status:
             self.assertEqual(status, ['write1', ['write2']])
 
             self.status2.write('write3')
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(status, ['write1', ['write2', 'write3']])
 
             mock_handle_new_status.reset_mock()
             self.status2.intermediate('interm1')
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(
                 status,
                 [
@@ -460,7 +460,7 @@ class StatusReader__init(IsolatedAsyncioTestCase):
 
             mock_handle_new_status.reset_mock()
             self.status2.intermediate('interm2')
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(
                 status,
                 [
@@ -509,7 +509,7 @@ class StatusReader__init(IsolatedAsyncioTestCase):
 
             mock_handle_new_status.reset_mock()
             self.status2.intermediate(None)
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(
                 status,
                 [
@@ -546,7 +546,7 @@ class StatusReader__init(IsolatedAsyncioTestCase):
 
             mock_handle_new_status.reset_mock()
             self.status2.write('write4')
-            wait_for_watchdog()
+            await wait_for_watchdog()
             self.assertEqual(
                 mock_handle_new_status.call_args_list,
                 [


### PR DESCRIPTION
- `Batch.run` and `Batch.cancel` now are co-routines
- `StatusReader` now is an async context manager
- `StatusReader.handle_new_status` now runs on the same thread which the `StatusReader` was instantiated in